### PR TITLE
chore: add test post + start command

### DIFF
--- a/eleventy-site/package.json
+++ b/eleventy-site/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "eleventy --serve",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/eleventy-site/src/posts/test-post.md
+++ b/eleventy-site/src/posts/test-post.md
@@ -1,0 +1,12 @@
+---
+date: '2024-02-26'
+title: "Test post"
+description: 'Test description'
+tags: ['test']
+---
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.<!-- excerpt -->


### PR DESCRIPTION
Looks like this was caused by not having anything valid in the `/posts/` directory so it didn't have anything to loop through and populate the index. I threw in a starter/test post and also updated `package.json` to contain a `start` command to run from the command line. :)